### PR TITLE
Atom group number revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-bodr
+BODR
 ====
 
 Blue Obelisk Data Repository - your one stop place of element and isotope data.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+bodr
+====
+
+Blue Obelisk Data Repository - your one stop place of element and isotope data.
+
+Fork to correct groups of some of the chemical elements.

--- a/bodr/elements/elements.xml
+++ b/bodr/elements/elements.xml
@@ -23,6 +23,7 @@
     <metadata name="dc:contributor" content="Geoffrey R. Hutchison" />
     <metadata name="dc:contributor" content="Carsten Niehaus" />
     <metadata name="dc:contributor" content="Egon Willighagen" />
+    <metadata name="dc:contributor" content="Bert de Jong" />
     <metadata name="dc:description" content="Database of elements and elemental properties (names, symbols, masses, exact masses, van der Waals radii, ionization potential, electron affinity, electronegativity, etc." />
   </metadataList>
 
@@ -46,7 +47,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="3">0.75420375</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.20</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'hydro' and 'gennao' for 'forms water'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">0.37</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">0.32</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">1.2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">1.00 1.00 1.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">20.28</scalar>
@@ -69,7 +70,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">24.5874</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">The Greek word for the sun was 'helios'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">0.32</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">0.46</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">1.4</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.85 1.00 1.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">4.216</scalar>
@@ -93,7 +94,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="21">0.618049</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">0.98</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'lithos' means 'stone'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.34</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.33</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.80 0.50 1.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">1615</scalar>
@@ -117,7 +118,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.57</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'beryllos' for 'light-green stone'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">0.90</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.02</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">1.9</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.76 1.00 0.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3243</scalar>
@@ -141,7 +142,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="25">0.279723</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.04</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Boron means 'Bor(ax) + (carb)on'. It is found in borax and behaves a lot like carbon</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">0.82</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">0.85</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">1.8</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">1.00 0.71 0.71</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">4275</scalar>
@@ -165,7 +166,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="20">1.262118</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.55</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Latin 'carboneum' for carbon</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">0.77</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">0.75</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">1.7</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.50 0.50 0.50</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">5100</scalar>
@@ -188,7 +189,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="2">-0.07</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">3.04</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Latin 'nitrogenium' ('forms saltpeter')</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">0.75</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">0.71</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">1.6</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.05 0.05 1.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">77.344</scalar>
@@ -212,7 +213,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="27">1.4611120</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">3.44</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Latin 'oxygenium' (forms acids)</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">0.73</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">0.63</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">1.55</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">1.00 0.05 0.05</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">90.188</scalar>
@@ -236,7 +237,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="32">3.4011887</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">3.98</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Latin 'fluere' ('floats')</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">0.71</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">0.64</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">1.5</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.70 1.00 1.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">85</scalar>
@@ -259,7 +260,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">21.5645</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'neo'. meaning 'new'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">0.69</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">0.67</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">1.54</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.70 0.89 0.96</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">27.1</scalar>
@@ -283,7 +284,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="25">0.547926</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">0.93</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Arabic 'natrun' for 'soda'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.54</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.55</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.4</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.67 0.36 0.95</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">1156</scalar>
@@ -307,7 +308,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.31</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the city of Magnesia</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.30</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.39</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.54 1.00 0.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">1380</scalar>
@@ -331,7 +332,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="5">0.43283</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.61</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Latin 'alumen'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.18</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.26</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.1</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.75 0.65 0.65</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">2740</scalar>
@@ -355,7 +356,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="20">1.389521</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.90</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Latin 'silex'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.11</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.16</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.1</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.50 0.60 0.60</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">2630</scalar>
@@ -379,7 +380,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="3">0.7465</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.19</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'phosphoros' for 'carries light'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.06</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.11</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">1.95</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">1.00 0.50 0.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">553</scalar>
@@ -403,7 +404,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="10">2.0771029</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.58</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">In sanskrit 'sweb' means 'to sleep'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.02</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.03</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">1.8</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">1.00 1.00 0.19</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">717.82</scalar>
@@ -449,7 +450,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">15.7596</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'aergon' for 'inactive'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">0.97</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">0.96</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">1.88</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.50 0.82 0.89</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">87.45</scalar>
@@ -497,7 +498,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="10">0.02455</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.00</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Latin 'calx' for 'lime'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.74</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.71</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.4</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.24 1.00 0.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">1757</scalar>
@@ -521,7 +522,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="20">0.188</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.36</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named because it was found in Scandinavia</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.44</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.48</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.3</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.90 0.90 0.90</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3109</scalar>
@@ -569,7 +570,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="12">0.525</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.63</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">'Vanadis' is another name for the Nordic goddess Freyja</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.25</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.34</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.05</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.65 0.65 0.67</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3650</scalar>
@@ -593,7 +594,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="12">0.67584</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.66</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'chroma' means 'color'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.27</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.22</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.05</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.54 0.60 0.78</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">2945</scalar>
@@ -617,7 +618,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.55</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">It was discovered near a town named Magnesia in black earth. Thus, it was named 'magnesia nigra', or for short, Manganese.</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.39</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.19</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.05</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.61 0.48 0.78</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">2235</scalar>
@@ -641,7 +642,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="3">0.151</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.83</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Latin 'ferrum'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.25</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.16</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.05</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.50 0.48 0.78</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3023</scalar>
@@ -664,7 +665,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="6">0.6633</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.88</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the German word 'Kobold' for 'goblin'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.26</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.11</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.44 0.48 0.78</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3143</scalar>
@@ -688,7 +689,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="12">1.15716</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.91</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">'Nickel' was the name of a mountain goblin</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.21</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.10</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.36 0.48 0.76</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3005</scalar>
@@ -712,7 +713,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="4">1.23578</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.90</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'cuprum' for Cypres</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.38</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.12</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">1.00 0.48 0.38</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">2840</scalar>
@@ -735,7 +736,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.65</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">German 'zinking' for 'rough', because zinc ore is very rough</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.31</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.18</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.1</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.49 0.50 0.69</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">1180</scalar>
@@ -759,7 +760,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="4">0.41</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.81</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">'Gallia' is an old name for France</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.26</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.24</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.1</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.76 0.56 0.56</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">2478</scalar>
@@ -783,7 +784,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="15">1.232712</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.01</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Latin 'germania' is an old name for Germany</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.22</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.21</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.1</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.40 0.56 0.56</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3107</scalar>
@@ -807,7 +808,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="8">0.814</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.18</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'arsenikos' for 'male' or 'bold'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.19</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.21</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.05</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.74 0.50 0.89</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">876</scalar>
@@ -878,7 +879,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">3.00</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'kryptos' for 'hidden'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.10</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.17</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.02</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.36 0.72 0.82</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">120.85</scalar>
@@ -902,7 +903,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="20">0.485916</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">0.82</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Latin 'rubidus' for 'dark red'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">2.11</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">2.10</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.9</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.44 0.18 0.69</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">961</scalar>
@@ -926,7 +927,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="6">0.05206</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">0.95</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the mineral Strontianit</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.92</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.85</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.55</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.00 1.00 0.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">1655</scalar>
@@ -950,7 +951,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="12">0.307</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.22</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the small town of Ytterby near Stockholm in Sweden. Terbium. Ytterbium and Gadolinium are also named after this town.</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.62</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.63</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.4</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.58 1.00 1.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3611</scalar>
@@ -974,7 +975,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="14">0.426</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.33</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the mineral zircon</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.48</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.54</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.3</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.58 0.88 0.88</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">4682</scalar>
@@ -998,7 +999,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="25">0.893</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.6</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after Niobe, the daughter of the Greek god Tantalus.</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.37</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.47</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.15</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.45 0.76 0.79</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">5015</scalar>
@@ -1022,7 +1023,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="2">0.7472</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.16</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">This name has Greek roots. It means 'like Platinum' - it was difficult to distinguish Molybdenum from Platinum.</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.45</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.38</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.1</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.33 0.71 0.71</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">4912</scalar>
@@ -1046,7 +1047,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="20">0.55</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.9</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'technetos' for artificial</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.56</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.28</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.05</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.23 0.62 0.62</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">4538</scalar>
@@ -1070,7 +1071,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="25">1.04638</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.2</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Ruthenia is the old name of Russia</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.26</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.25</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.05</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.14 0.56 0.56</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">4425</scalar>
@@ -1094,7 +1095,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="20">1.14289</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.28</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'rhodeos' means 'red like a rose'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.35</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.25</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.04 0.49 0.55</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3970</scalar>
@@ -1118,7 +1119,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="12">0.56214</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.20</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the asteroid Pallas</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.31</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.20</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.05</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.00 0.41 0.52</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3240</scalar>
@@ -1141,7 +1142,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="2">1.30447</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.93</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Latin 'argentum' for silver</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.53</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.28</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.1</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.88 0.88 1.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">2436</scalar>
@@ -1164,7 +1165,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.69</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'kadmia' ('Galmei' = Zinc carbonate)</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.48</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.36</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">1.00 0.85 0.56</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">1040</scalar>
@@ -1188,7 +1189,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="9">0.404</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.78</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after 'Indigo' because of its blue spectrum</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.44</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.42</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.65 0.46 0.45</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">2350</scalar>
@@ -1212,7 +1213,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="15">1.112066</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.96</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Latin 'stannum' for tin</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.41</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.40</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.25</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.40 0.50 0.50</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">2876</scalar>
@@ -1235,7 +1236,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="20">1.047401</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.05</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Arabic 'anthos ammonos' for 'blossom of the god Ammon'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.38</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.40</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.62 0.39 0.71</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">1860</scalar>
@@ -1258,7 +1259,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="7">1.970875</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.1</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Latin 'tellus' or 'telluris' for 'Planet Earth'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.35</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.36</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.1</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.83 0.48 0.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">1261</scalar>
@@ -1306,7 +1307,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.6</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'xenos' for 'foreigner'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.30</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.31</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.16</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.26 0.62 0.69</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">165.1</scalar>
@@ -1330,7 +1331,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="25">0.471626</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">0.79</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Latin 'caesius' for 'heaven blue'.</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">2.25</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">2.32</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">3</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.34 0.09 0.56</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">944</scalar>
@@ -1354,7 +1355,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="6">0.14462</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">0.89</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'barys' for 'heavy'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.98</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.96</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.7</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.00 0.79 0.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">2078</scalar>
@@ -1378,7 +1379,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="2">0.47</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.10</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'lanthanein' for 'hidden'. The Lanthanoids are also called the 'rare earth' elements.</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.69</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.80</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.5</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.44 0.83 1.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3737</scalar>
@@ -1402,6 +1403,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0.5</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.12</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the planetoid Ceres</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.63</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.48</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">1.00 1.00 0.78</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3715</scalar>
@@ -1424,6 +1426,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0.5</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.13</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'prasinos didymos' for 'green twin'</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.76</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.47</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.85 1.00 0.78</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3785</scalar>
@@ -1446,6 +1449,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0.5</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.14</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'neos didymos' for 'new twin'</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.74</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.45</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.78 1.00 0.78</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3347</scalar>
@@ -1467,6 +1471,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">5.582</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0.5</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the Greek Prometheus. Prometheus stole the fire from the gods and gave it to mankind.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.73</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.43</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.64 1.00 0.78</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3273</scalar>
@@ -1489,6 +1494,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0.5</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.17</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the mineral Samarskit</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.72</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.42</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.56 1.00 0.78</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">2067</scalar>
@@ -1510,6 +1516,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">5.6704</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0.5</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after Europe</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.68</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.4</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.38 1.00 0.78</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">1800</scalar>
@@ -1532,6 +1539,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0.5</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.20</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the Finnish chemist Johan Gadolin</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.69</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.38</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.27 1.00 0.78</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3545</scalar>
@@ -1553,6 +1561,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">5.8638</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0.5</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the Swedish town of Ytterby</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.68</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.37</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.19 1.00 0.78</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3500</scalar>
@@ -1575,6 +1584,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0.5</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.22</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'dysprositor' for 'difficult to reach'</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.67</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.35</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.12 1.00 0.78</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">2840</scalar>
@@ -1597,6 +1607,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0.5</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.23</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Latin 'holmia' for the old name of Stockholm</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.66</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.33</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.00 1.00 0.61</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">2968</scalar>
@@ -1619,6 +1630,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0.5</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.24</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named ofter the Swedish town of Ytterby. Terbium and Ytterbium are also named after this town.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.65</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.32</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.00 0.90 0.46</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3140</scalar>
@@ -1641,6 +1653,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0.5</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.25</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the old name of Scandinavia, 'Thule'.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.64</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.3</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.00 0.83 0.32</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">2223</scalar>
@@ -1662,6 +1675,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">6.2542</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0.5</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Like Terbium and Gadolinium, this is named after the Swedish town of Ytterby.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.70</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.28</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.00 0.75 0.22</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">1469</scalar>
@@ -1684,7 +1698,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0.5</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.27</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the Roman name 'Lutetia' for Paris</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.60</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.62</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.27</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.00 0.67 0.14</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3668</scalar>
@@ -1707,7 +1721,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.3</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">'Hafnia' is the old name of Kopenhagen (Denmark)</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.50</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.52</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.25</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.30 0.76 1.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">4875</scalar>
@@ -1731,7 +1745,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="12">0.322</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.5</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the Greek myth of Tantalos</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.38</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.46</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.30 0.65 1.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">5730</scalar>
@@ -1755,7 +1769,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="8">0.815</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.36</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">'tung sten' means 'heavy stone' in Swedish. The old name (and thus the symbol 'W') was Wolfram, named after a mineral.</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.46</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.37</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.1</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.13 0.58 0.84</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">5825</scalar>
@@ -1779,7 +1793,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="15">0.15</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.9</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the German river Rhine (latin 'Rhenium').</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.59</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.31</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.05</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.15 0.49 0.67</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">5870</scalar>
@@ -1803,7 +1817,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="12">1.07780</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.2</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek for 'smell'. Its oxides smell strongly like radishes.</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.28</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.29</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.15 0.40 0.59</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">5300</scalar>
@@ -1827,7 +1841,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="15">1.56436</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.20</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'iris' for 'rainbow'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.37</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.22</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.09 0.33 0.53</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">4700</scalar>
@@ -1851,7 +1865,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="5">2.12510</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.28</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Spanish 'platina' means 'small silver'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.28</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.23</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.05</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.96 0.93 0.82</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">4100</scalar>
@@ -1875,7 +1889,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="3">2.30861</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.54</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Latin 'aurum'. Named after Aurora, the goddess of sunrise</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.44</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.24</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.1</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.80 0.82 0.12</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3130</scalar>
@@ -1898,7 +1912,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.00</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Graeco-Latin 'hydrargyrum' for 'liquid silver'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.49</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.33</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.05</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.71 0.71 0.76</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">629.88</scalar>
@@ -1921,7 +1935,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="13">0.377</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.62</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'tallos' for 'young twig'</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.48</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.44</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.65 0.33 0.30</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">1746</scalar>
@@ -1945,7 +1959,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="8">0.364</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.33</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Latin 'plumbum' for Lead</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.47</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.44</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.3</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.34 0.35 0.38</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">2023</scalar>
@@ -1968,7 +1982,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="25">0.942363</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.02</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">The old name of Bismuth is 'Wismut', which stood for 'white mass'.</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.46</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.51</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.3</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.62 0.31 0.71</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">1837</scalar>
@@ -1991,6 +2005,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="3">1.9</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.0</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after Poland to honor Marie Curie</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.45</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.67 0.36 0.00</array>
     <scalar dataType="xsd:float" dictRef="bo:meltingpoint"  units="siUnits:kelvin">527</scalar>
@@ -2013,6 +2028,7 @@
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev" errorValue="2">2.8</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">2.2</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'astator' for 'changing'</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.47</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.46 0.31 0.27</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">610</scalar>
@@ -2035,7 +2051,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">10.7485</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronAffinity" units="units:ev">0</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after Radium. It ends with 'on' to make it clear that it is a noble gas.</scalar>
-    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.45</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.42</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.26 0.51 0.59</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">211.4</scalar>
@@ -2058,6 +2074,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">4.0727</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">0.7</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after France to honor Marguerite Perey</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">2.23</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.26 0.00 0.40</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">950</scalar>
@@ -2080,6 +2097,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">5.2784</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">0.9</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Latin 'radius' for 'beam', as it is radioactive</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">2.01</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.00 0.49 0.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">1413</scalar>
@@ -2102,6 +2120,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">5.17</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.1</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'aktis' for 'beam' - actinium is radioactive</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.86</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.44 0.67 0.98</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3470</scalar>
@@ -2124,6 +2143,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">6.3067</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.3</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the German god of thunder: Thor</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.75</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.4</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.00 0.73 1.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">5060</scalar>
@@ -2145,6 +2165,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">5.89</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.5</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'protos' for 'ancester'. Protactinium is before Actinium in the periodic table.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.69</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.00 0.63 1.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">4300</scalar>
@@ -2166,6 +2187,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">6.1941</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.38</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Greek 'ouranos' for 'heaven'. Named after the planet Uranus.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.70</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2.3</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.00 0.56 1.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">4407</scalar>
@@ -2187,6 +2209,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">6.2657</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.36</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the planet Neptune.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.71</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.00 0.50 1.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">4175</scalar>
@@ -2208,6 +2231,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">6.0260</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.28</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the planet Pluto.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.72</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.00 0.42 1.00</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3505</scalar>
@@ -2229,6 +2253,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">5.9738</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.3</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after America.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.66</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.33 0.36 0.95</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">2880</scalar>
@@ -2250,6 +2275,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">5.9914</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.3</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after Marie Curie.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.66</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.47 0.36 0.89</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">3383</scalar>
@@ -2271,6 +2297,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">6.1979</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.3</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the town Berkeley where it was discovered.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.68</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.54 0.31 0.89</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">983</scalar>
@@ -2292,6 +2319,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">6.2817</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.3</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the US-State of California.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.68</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.63 0.21 0.83</array>
     <scalar dataType="xsd:float" dictRef="bo:boilingpoint"  units="siUnits:kelvin">1173</scalar>
@@ -2313,6 +2341,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">6.42</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.3</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the scientist Albert Einstein.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.65</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.70 0.12 0.83</array>
     <scalar dataType="xsd:float" dictRef="bo:meltingpoint"  units="siUnits:kelvin">1130</scalar>
@@ -2333,6 +2362,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">6.50</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.3</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the scientist Enrico Fermi.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.67</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.70 0.12 0.73</array>
     <scalar dataType="xsd:float" dictRef="bo:meltingpoint"  units="siUnits:kelvin">1800</scalar>
@@ -2353,6 +2383,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">6.58</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.3</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the scientist D.I. Mendeleev.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.73</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.70 0.05 0.65</array>
     <scalar dataType="xsd:float" dictRef="bo:meltingpoint"  units="siUnits:kelvin">1100</scalar>
@@ -2373,6 +2404,7 @@
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">6.65</scalar>
     <scalar dataType="xsd:float" dictRef="bo:electronegativityPauling" units="boUnits:paulingScaleUnit">1.3</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the scientist Alfred Nobel.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.76</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.74 0.05 0.53</array>
     <scalar dataType="xsd:float" dictRef="bo:meltingpoint"  units="siUnits:kelvin">1100</scalar>
@@ -2391,6 +2423,7 @@
     <scalar dataType="xsd:float" dictRef="bo:exactMass" units="units:atmass">262.10963</scalar>
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">4.9</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the scientist Ernest Orlando Lawrence.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.61</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.78 0.00 0.40</array>
     <scalar dataType="xsd:float" dictRef="bo:meltingpoint"  units="siUnits:kelvin">1900</scalar>
@@ -2410,6 +2443,7 @@
     <scalar dataType="xsd:float" dictRef="bo:exactMass" units="units:atmass">261.10877</scalar>
     <scalar dataType="xsd:float" dictRef="bo:ionization" units="units:ev">6.0</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the scientist Ernest Rutherford</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.57</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.80 0.00 0.35</array>
     <scalar dataType="xsd:string" dictRef="bo:periodTableBlock">d</scalar>
@@ -2427,6 +2461,7 @@
     <scalar dataType="xsd:float" dictRef="bo:mass" units="units:atmass">270</scalar>
     <scalar dataType="xsd:float" dictRef="bo:exactMass" units="units:atmass">262.11408</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the science-town Dubna in Russia</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.49</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.82 0.00 0.31</array>
     <scalar dataType="xsd:string" dictRef="bo:periodTableBlock">d</scalar>
@@ -2444,6 +2479,7 @@
     <scalar dataType="xsd:float" dictRef="bo:mass" units="units:atmass">271</scalar>
     <scalar dataType="xsd:float" dictRef="bo:exactMass" units="units:atmass">263.11832</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the scientist G. Theodore Seaborg.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.43</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.85 0.00 0.27</array>
     <scalar dataType="xsd:string" dictRef="bo:periodTableBlock">d</scalar>
@@ -2461,6 +2497,7 @@
     <scalar dataType="xsd:float" dictRef="bo:mass" units="units:atmass">270</scalar>
     <scalar dataType="xsd:float" dictRef="bo:exactMass" units="units:atmass">264.1246</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the scientist Niels Bohr.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.41</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.88 0.00 0.22</array>
     <scalar dataType="xsd:string" dictRef="bo:periodTableBlock">d</scalar>
@@ -2478,6 +2515,7 @@
     <scalar dataType="xsd:float" dictRef="bo:mass" units="units:atmass">277</scalar>
     <scalar dataType="xsd:float" dictRef="bo:exactMass" units="units:atmass">265.13009</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Latin 'hassia' for the German county Hessen. In Hessen a lot elements have been discovered.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.34</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.90 0.00 0.18</array>
     <scalar dataType="xsd:string" dictRef="bo:periodTableBlock">d</scalar>
@@ -2495,6 +2533,7 @@
     <scalar dataType="xsd:float" dictRef="bo:mass" units="units:atmass">276</scalar>
     <scalar dataType="xsd:float" dictRef="bo:exactMass" units="units:atmass">268.13873</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the scientist Lise Meitner.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.29</scalar>
     <scalar dataType="xsd:float" dictRef="bo:radiusVDW" units="units:ang">2</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.91 0.00 0.15</array>
     <scalar dataType="xsd:string" dictRef="bo:periodTableBlock">d</scalar>
@@ -2512,6 +2551,7 @@
     <scalar dataType="xsd:float" dictRef="bo:mass" units="units:atmass">281</scalar>
     <scalar dataType="xsd:float" dictRef="bo:exactMass" units="units:atmass">271.14606</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after the German city Darmstadt where many elements have been discovered.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.28</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.92 0.00 0.14</array>
     <scalar dataType="xsd:string" dictRef="bo:periodTableBlock">d</scalar>
     <array dataType="xsd:string" dictRef="bo:discoveryCountry">de</array>
@@ -2528,6 +2568,7 @@
     <scalar dataType="xsd:float" dictRef="bo:mass" units="units:atmass">282</scalar>
     <scalar dataType="xsd:float" dictRef="bo:exactMass" units="units:atmass">272.15362</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Named after Wilhelm Conrad Röntgen.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.21</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.93 0.00 0.13</array>
     <scalar dataType="xsd:string" dictRef="bo:periodTableBlock">d</scalar>
     <array dataType="xsd:string" dictRef="bo:discoveryCountry">de</array>
@@ -2544,6 +2585,7 @@
     <scalar dataType="xsd:float" dictRef="bo:mass" units="units:atmass">285</scalar>
     <scalar dataType="xsd:float" dictRef="bo:exactMass" units="units:atmass">285.17411</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Historically known as eka-mercury. Named in honor of the astronomer Nicolaus Copernicus. The temporary IUPAC systematic element name was Ununbium.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.22</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.94 0.00 0.12</array>
     <scalar dataType="xsd:string" dictRef="bo:periodTableBlock">d</scalar>
     <array dataType="xsd:string" dictRef="bo:discoveryCountry">de</array>
@@ -2560,6 +2602,7 @@
     <scalar dataType="xsd:float" dictRef="bo:mass" units="units:atmass">285</scalar>
     <scalar dataType="xsd:float" dictRef="bo:exactMass" units="units:atmass">284.17808</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Historically known as eka-thallium. Ununtrium is a temporary IUPAC systematic element name.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.36</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.95 0.00 0.11</array>
     <scalar dataType="xsd:string" dictRef="bo:periodTableBlock">p</scalar>
     <array dataType="xsd:string" delimiter="," size="2" dictRef="bo:discoveryCountry">ru,us</array>
@@ -2576,6 +2619,7 @@
     <scalar dataType="xsd:float" dictRef="bo:mass" units="units:atmass">289</scalar>
     <scalar dataType="xsd:float" dictRef="bo:exactMass" units="units:atmass">289.18728</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Historically known as eka-lead. Named after the Flerov Laboratory of Nuclear Reactions of the Joint Inst. for Nuclear Research (JINR), Russia, where it was discovered. The temporary IUPAC systematic element name was Ununquadium.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.43</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.96 0.00 0.10</array>
     <scalar dataType="xsd:string" dictRef="bo:periodTableBlock">p</scalar>
     <array dataType="xsd:string" delimiter="," size="2" dictRef="bo:discoveryCountry">ru,us</array>
@@ -2592,6 +2636,7 @@
     <scalar dataType="xsd:float" dictRef="bo:mass" units="units:atmass">289</scalar>
     <scalar dataType="xsd:float" dictRef="bo:exactMass" units="units:atmass">288.19249</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Historically known as eka-bismuth. Ununpentium is a temporary IUPAC systematic element name.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.62</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.97 0.00 0.09</array>
     <scalar dataType="xsd:string" dictRef="bo:periodTableBlock">p</scalar>
     <array dataType="xsd:string" delimiter="," size="2" dictRef="bo:discoveryCountry">ru,us</array>
@@ -2608,6 +2653,7 @@
     <scalar dataType="xsd:float" dictRef="bo:mass" units="units:atmass">293</scalar>
     <scalar dataType="xsd:float" dictRef="bo:exactMass" units="units:atmass">292.19979</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Historically known as eka-polonium. The name recognizes the Lawrence Livermore National Laboratory, California, which collaborated with the Joint Inst. for Nuclear Research (JINR), Russia on the discovery. The temporary IUPAC systematic element name was Ununhexium.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.75</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.98 0.00 0.08</array>
     <scalar dataType="xsd:string" dictRef="bo:periodTableBlock">p</scalar>
     <array dataType="xsd:string" dictRef="bo:discoveryCountry">ru</array>
@@ -2623,6 +2669,7 @@
     <label dictRef="bo:name" xml:lang="en" value="Ununseptium" />
     <scalar dataType="xsd:float" dictRef="bo:mass" units="units:atmass">294</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Temporary symbol and name. Can also be referred to as eka-astatine.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.65</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">0.99 0.00 0.07</array>
     <scalar dataType="xsd:string" dictRef="bo:periodTableBlock">p</scalar>
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">0</scalar>
@@ -2636,6 +2683,7 @@
     <label dictRef="bo:name" xml:lang="en" value="Ununoctium" />
     <scalar dataType="xsd:float" dictRef="bo:mass" units="units:atmass">294</scalar>
     <scalar dataType="xsd:string" dictRef="bo:nameOrigin" xml:lang="en">Historically known as eka-radon, eka-emanation before 1960. Ununoctium is a temporary IUPAC systematic element name.</scalar>
+    <scalar dataType="xsd:float" dictRef="bo:radiusCovalent" units="units:ang">1.57</scalar>
     <array title="color" dictRef="bo:elementColor" size="3" dataType="xsd:float">1.00 0.00 0.06</array>
     <scalar dataType="xsd:string" dictRef="bo:periodTableBlock">p</scalar>
     <array dataType="xsd:string" delimiter="," size="2" dictRef="bo:discoveryCountry">ru,us</array>

--- a/bodr/elements/elements.xml
+++ b/bodr/elements/elements.xml
@@ -79,7 +79,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1895</scalar>
     <array dataType="xsd:string" delimiter=";" size="2" dictRef="bo:discoverers">P. J. Janssen;J. N. Lockyer</array>
     <scalar dataType="xsd:int" dictRef="bo:period">1</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">8</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">18</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">1s2</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Noblegas</scalar>
   </atom>
@@ -151,7 +151,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1808</scalar>
     <array dataType="xsd:string" delimiter=";" size="2" dictRef="bo:discoverers">Louis Joseph Gay-Lussac;Louis Jacques Thenard</array>
     <scalar dataType="xsd:int" dictRef="bo:period">2</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">3</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">13</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">He 2s2 2p1</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Metalloids</scalar>
   </atom>
@@ -174,7 +174,7 @@
     <array dataType="xsd:string" dictRef="bo:discoveryCountry">ancient</array>
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">0</scalar>
     <scalar dataType="xsd:int" dictRef="bo:period">2</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">4</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">14</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">He 2s2 2p2</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Non-Metal</scalar>
   </atom>
@@ -198,7 +198,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1772</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">D. Rutherford</array>
     <scalar dataType="xsd:int" dictRef="bo:period">2</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">5</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">15</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">He 2s2 2p3</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Non-Metal</scalar>
   </atom>
@@ -222,7 +222,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1774</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">J. Priestley</array>
     <scalar dataType="xsd:int" dictRef="bo:period">2</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">6</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">16</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">He 2s2 2p4</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Non-Metal</scalar>
   </atom>
@@ -246,7 +246,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1886</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">H. F. Moissan</array>
     <scalar dataType="xsd:int" dictRef="bo:period">2</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">7</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">17</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">He 2s2 2p5</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Halogen</scalar>
   </atom>
@@ -269,7 +269,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1898</scalar>
     <array dataType="xsd:string" delimiter=";" size="2" dictRef="bo:discoverers">W. Ramsay;M.W. Travers</array>
     <scalar dataType="xsd:int" dictRef="bo:period">2</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">8</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">18</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">He 2s2 2p6</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Noblegas</scalar>
   </atom>
@@ -341,7 +341,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1825</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">H. Ch. Oersted</array>
     <scalar dataType="xsd:int" dictRef="bo:period">3</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">3</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">13</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Ne 3s2 3p1</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Other_Metal</scalar>
   </atom>
@@ -365,7 +365,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1823</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">J. J. Berzelius</array>
     <scalar dataType="xsd:int" dictRef="bo:period">3</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">4</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">14</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Ne 3s2 3p2</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Metalloids</scalar>
   </atom>
@@ -389,7 +389,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1669</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">H. Brandt</array>
     <scalar dataType="xsd:int" dictRef="bo:period">3</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">5</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">15</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Ne 3s2 3p3</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Non-Metal</scalar>
   </atom>
@@ -412,7 +412,7 @@
     <array dataType="xsd:string" dictRef="bo:discoveryCountry">ancient</array>
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">0</scalar>
     <scalar dataType="xsd:int" dictRef="bo:period">3</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">6</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">16</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Ne 3s2 3p4</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Non-Metal</scalar>
   </atom>
@@ -436,7 +436,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1774</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">C. W. Scheele</array>
     <scalar dataType="xsd:int" dictRef="bo:period">3</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">7</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">17</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Ne 3s2 3p5</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Halogen</scalar>
   </atom>
@@ -459,7 +459,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1894</scalar>
     <array dataType="xsd:string" delimiter=";" size="2" dictRef="bo:discoverers">W. Ramsay;J. Rayleigh</array>
     <scalar dataType="xsd:int" dictRef="bo:period">3</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">8</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">18</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Ne 3s2 3p6</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Noblegas</scalar>
   </atom>
@@ -674,7 +674,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1737</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">G. Brandt</array>
     <scalar dataType="xsd:int" dictRef="bo:period">4</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">8</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">9</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Ar 3d7 4s2</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Transition</scalar>
   </atom>
@@ -698,7 +698,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1751</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">A. F. Cronstedt</array>
     <scalar dataType="xsd:int" dictRef="bo:period">4</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">8</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">10</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Ar 3d8 4s2</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Transition</scalar>
   </atom>
@@ -721,7 +721,7 @@
     <array dataType="xsd:string" dictRef="bo:discoveryCountry">ancient</array>
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">0</scalar>
     <scalar dataType="xsd:int" dictRef="bo:period">4</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">1</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">11</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Ar 3d10 4s1</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Transition</scalar>
   </atom>
@@ -745,7 +745,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1746</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">Andreas Marggraf</array>
     <scalar dataType="xsd:int" dictRef="bo:period">4</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">2</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">12</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Ar 3d10 4s2</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Transition</scalar>
   </atom>
@@ -769,7 +769,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1875</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">P. E. Lecoq de Boisbaudran</array>
     <scalar dataType="xsd:int" dictRef="bo:period">4</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">3</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">13</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Ar 3d10 4s2 4p1</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Other_Metal</scalar>
   </atom>
@@ -793,7 +793,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1886</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">C. A. Winkler</array>
     <scalar dataType="xsd:int" dictRef="bo:period">4</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">4</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">14</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Ar 3d10 4s2 4p2</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Metalloids</scalar>
   </atom>
@@ -816,7 +816,7 @@
     <array dataType="xsd:string" dictRef="bo:discoveryCountry">ancient</array>
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">0</scalar>
     <scalar dataType="xsd:int" dictRef="bo:period">4</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">5</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">15</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Ar 3d10 4s2 4p3</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Metalloids</scalar>
   </atom>
@@ -840,7 +840,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1817</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">J. J. Berzelius</array>
     <scalar dataType="xsd:int" dictRef="bo:period">4</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">6</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">16</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Ar 3d10 4s2 4p4</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Non-Metal</scalar>
   </atom>
@@ -864,7 +864,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1826</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">A. J. Balard</array>
     <scalar dataType="xsd:int" dictRef="bo:period">4</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">7</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">17</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Ar 3d10 4s2 4p5</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Halogen</scalar>
   </atom>
@@ -888,7 +888,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1898</scalar>
     <array dataType="xsd:string" delimiter=";" size="2" dictRef="bo:discoverers">W. Ramsay;M. W. Travers</array>
     <scalar dataType="xsd:int" dictRef="bo:period">4</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">8</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">18</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Ar 3d10 4s2 4p6</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Noblegas</scalar>
   </atom>
@@ -1104,7 +1104,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1803</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">W. Wollaston</array>
     <scalar dataType="xsd:int" dictRef="bo:period">5</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">8</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">9</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Kr 4d8 5s1</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Transition</scalar>
   </atom>
@@ -1127,7 +1127,7 @@
     <array dataType="xsd:string" dictRef="bo:discoveryCountry">uk</array>
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1803</scalar>
     <scalar dataType="xsd:int" dictRef="bo:period">5</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">8</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">10</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Kr 4d10</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Transition</scalar>
   </atom>
@@ -1150,7 +1150,7 @@
     <array dataType="xsd:string" dictRef="bo:discoveryCountry">ancient</array>
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">0</scalar>
     <scalar dataType="xsd:int" dictRef="bo:period">5</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">1</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">11</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Kr 4d10 5s1</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Transition</scalar>
   </atom>
@@ -1174,7 +1174,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1817</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">F. Stromeyer</array>
     <scalar dataType="xsd:int" dictRef="bo:period">5</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">2</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">12</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Kr 4d10 5s2</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Transition</scalar>
   </atom>
@@ -1198,7 +1198,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1863</scalar>
     <array dataType="xsd:string" delimiter=";" size="2" dictRef="bo:discoverers">F. Reich;H.T. Richter</array>
     <scalar dataType="xsd:int" dictRef="bo:period">5</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">3</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">13</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Kr 4d10 5s2 5p1</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Other_Metal</scalar>
   </atom>
@@ -1221,7 +1221,7 @@
     <array dataType="xsd:string" dictRef="bo:discoveryCountry">ancient</array>
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">0</scalar>
     <scalar dataType="xsd:int" dictRef="bo:period">5</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">4</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">14</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Kr 4d10 5s2 5p2</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Other_Metal</scalar>
   </atom>
@@ -1244,7 +1244,7 @@
     <array dataType="xsd:string" dictRef="bo:discoveryCountry">ancient</array>
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">0</scalar>
     <scalar dataType="xsd:int" dictRef="bo:period">5</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">5</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">15</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Kr 4d10 5s2 5p3</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Metalloids</scalar>
   </atom>
@@ -1268,7 +1268,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1782</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">Franz Joseph Muller von Reichstein</array>
     <scalar dataType="xsd:int" dictRef="bo:period">5</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">6</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">16</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Kr 4d10 5s2 5p4</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Metalloids</scalar>
   </atom>
@@ -1292,7 +1292,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1811</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">Bernard Courtois</array>
     <scalar dataType="xsd:int" dictRef="bo:period">5</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">7</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">17</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Kr 4d10 5s2 5p5</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Halogen</scalar>
   </atom>
@@ -1316,7 +1316,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1898</scalar>
     <array dataType="xsd:string" delimiter=";" size="2" dictRef="bo:discoverers">W. Ramsay;M. W. Travers</array>
     <scalar dataType="xsd:int" dictRef="bo:period">5</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">8</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">18</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Kr 4d10 5s2 5p6</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Noblegas</scalar>
   </atom>
@@ -1837,7 +1837,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1804</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">S. Tennant</array>
     <scalar dataType="xsd:int" dictRef="bo:period">6</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">8</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">9</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Xe 4f14 5d7 6s2</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Transition</scalar>
   </atom>
@@ -1861,7 +1861,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1735</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">A. de Ulloa</array>
     <scalar dataType="xsd:int" dictRef="bo:period">6</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">8</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">10</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Xe 4f14 5d9 6s1</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Transition</scalar>
   </atom>
@@ -1884,7 +1884,7 @@
     <array dataType="xsd:string" dictRef="bo:discoveryCountry">ancient</array>
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">0</scalar>
     <scalar dataType="xsd:int" dictRef="bo:period">6</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">1</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">11</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Xe 4f14 5d10 6s1</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Transition</scalar>
   </atom>
@@ -1907,7 +1907,7 @@
     <array dataType="xsd:string" dictRef="bo:discoveryCountry">ancient</array>
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">0</scalar>
     <scalar dataType="xsd:int" dictRef="bo:period">6</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">2</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">12</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Xe 4f14 5d10 6s2</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Transition</scalar>
   </atom>
@@ -1931,7 +1931,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1861</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">W. Crookes</array>
     <scalar dataType="xsd:int" dictRef="bo:period">6</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">3</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">13</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Xe 4f14 5d10 6s2 6p1</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Other_Metal</scalar>
   </atom>
@@ -1954,7 +1954,7 @@
     <array dataType="xsd:string" dictRef="bo:discoveryCountry">ancient</array>
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">0</scalar>
     <scalar dataType="xsd:int" dictRef="bo:period">6</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">4</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">14</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Xe 4f14 5d10 6s2 6p2</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Other_Metal</scalar>
   </atom>
@@ -1977,7 +1977,7 @@
     <array dataType="xsd:string" dictRef="bo:discoveryCountry">ancient</array>
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">0</scalar>
     <scalar dataType="xsd:int" dictRef="bo:period">6</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">5</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">15</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Xe 4f14 5d10 6s2 6p3</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Other_Metal</scalar>
   </atom>
@@ -1999,7 +1999,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1898</scalar>
     <array dataType="xsd:string" delimiter=";" size="2" dictRef="bo:discoverers">M. Sklodowska-Curie;P. Curie</array>
     <scalar dataType="xsd:int" dictRef="bo:period">6</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">6</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">16</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Xe 4f14 5d10 6s2 6p4</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Metalloids</scalar>
   </atom>
@@ -2022,7 +2022,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1940</scalar>
     <array dataType="xsd:string" delimiter=";" size="3" dictRef="bo:discoverers">D. R. Corson;K. R. McKenzie;E. Segre</array>
     <scalar dataType="xsd:int" dictRef="bo:period">6</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">7</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">17</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Xe 4f14 5d10 6s2 6p5</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Halogen</scalar>
   </atom>
@@ -2045,7 +2045,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1898</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">E. Dorn</array>
     <scalar dataType="xsd:int" dictRef="bo:period">6</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">8</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">18</scalar>
     <scalar dataType="xsd:string" dictRef="bo:electronicConfiguration">Xe 4f14 5d10 6s2 6p6</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Noblegas</scalar>
   </atom>

--- a/bodr/elements/elements.xml
+++ b/bodr/elements/elements.xml
@@ -2534,7 +2534,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1994</scalar>
     <array dataType="xsd:string" delimiter=";" size="7" dictRef="bo:discoverers">S. Hofmann;V. Ninov;F. P. Hessberger;P. Armbruster;H. Folger;G. Münzenberg;et al.</array>
     <scalar dataType="xsd:int" dictRef="bo:period">7</scalar>
-    <scalar dataType="xsd:int" dictRef="bo:group">1</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">11</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Transition</scalar>
   </atom>
   <atom id="Cn">
@@ -2550,6 +2550,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1996</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">First created at the Gesellschaft für Schwerionenforschung</array>
     <scalar dataType="xsd:int" dictRef="bo:period">7</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">12</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Transition</scalar>
   </atom>
   <atom id="Uut">
@@ -2565,6 +2566,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">2003</scalar>
     <array dataType="xsd:string" delimiter=";" size="2" dictRef="bo:discoverers">Russian scientists at Dubna (JINR);American scientists at the Lawrence Livermore National Laboratory.</array>
     <scalar dataType="xsd:int" dictRef="bo:period">7</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">13</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Other_Metal</scalar>
   </atom>
   <atom id="Fl">
@@ -2580,6 +2582,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">1998</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">Joint Institute for Nuclear Research</array>
     <scalar dataType="xsd:int" dictRef="bo:period">7</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">14</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Other_Metal</scalar>
   </atom>
   <atom id="Uup">
@@ -2595,6 +2598,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">2004</scalar>
     <array dataType="xsd:string" delimiter=";" size="2" dictRef="bo:discoverers">Russian scientists at Dubna (JINR);American scientists at the Lawrence Livermore National Laboratory.</array>
     <scalar dataType="xsd:int" dictRef="bo:period">7</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">15</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Other_Metal</scalar>
   </atom>
   <atom id="Lv">
@@ -2610,6 +2614,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">2000</scalar>
     <array dataType="xsd:string" dictRef="bo:discoverers">Joint Institute for Nuclear Research</array>
     <scalar dataType="xsd:int" dictRef="bo:period">7</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">16</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Other_Metal</scalar>
   </atom>
   <atom id="Uus">
@@ -2622,6 +2627,7 @@
     <scalar dataType="xsd:string" dictRef="bo:periodTableBlock">p</scalar>
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">0</scalar>
     <scalar dataType="xsd:int" dictRef="bo:period">7</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">17</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Halogen</scalar>
   </atom>
   <atom id="Uuo">
@@ -2636,6 +2642,7 @@
     <scalar dataType="xsd:date" dictRef="bo:discoveryDate">2002</scalar>
     <array dataType="xsd:string" delimiter=";" size="2" dictRef="bo:discoverers">Russian scientists at Dubna (JINR);American scientists at the Lawrence Livermore National Laboratory.</array>
     <scalar dataType="xsd:int" dictRef="bo:period">7</scalar>
+    <scalar dataType="xsd:int" dictRef="bo:group">18</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Noblegas</scalar>
   </atom>
 </list>

--- a/bodr/elements/elements.xml
+++ b/bodr/elements/elements.xml
@@ -2597,7 +2597,7 @@
     <scalar dataType="xsd:int" dictRef="bo:period">7</scalar>
     <scalar dataType="xsd:string" dictRef="bo:family">Other_Metal</scalar>
   </atom>
-  <atom id="Fl">
+  <atom id="Lv">
     <scalar dataType="xsd:Integer" dictRef="bo:atomicNumber">116</scalar>
     <label dictRef="bo:symbol" value="Lv" />
     <label dictRef="bo:name" xml:lang="en" value="Livermorium" />

--- a/bodr/elements/radii-covalent.bibxml
+++ b/bodr/elements/radii-covalent.bibxml
@@ -1,15 +1,25 @@
 <bx:entry>
+  <bx:article>
+    <bx:author>P. Pyykko</bx:author>
+    <bx:author>M. Atsumi</bx:author>
+    <bx:journal>Chem. Eur. J.</bx:journal>
+    <bx:year>2009</bx:year>
+    <bx:volume>15</bx:volume>
+    <bx:pages>186</bx:pages>
+  </bx:article>
+</bx:entry>
+<bx:entry>
   <bx:misc>
     <bx:url>http://www.webelements.com/</bx:url>
   </bx:misc>
 </bx:entry>
-<bx:entry>
-  <bx:article>
-    <bx:author>A. Bondi</bx:author>
-    <bx:journal>J. Phys. Chem.</bx:journal>
-    <bx:year>1964</bx:year>
-    <bx:volume>68</bx:volume>
-    <bx:pages>441</bx:pages>
+ <bx:entry>
+   <bx:article>
+     <bx:author>A. Bondi</bx:author>
+     <bx:journal>J. Phys. Chem.</bx:journal>
+     <bx:year>1964</bx:year>
+     <bx:volume>68</bx:volume>
+     <bx:pages>441</bx:pages>
   </bx:article>
 </bx:entry>
 <bx:entry>


### PR DESCRIPTION
Changed group numbers for 44 elements to correspond to latest IUPAC recommendation.
Added group numbers to elements 112-118.
Fixed atom id for Livermorium.